### PR TITLE
[Demo] Add the order status table

### DIFF
--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -10,13 +10,16 @@ customers as (
 
 )
 ,
+statuses as (
+    select * from {{ ref('stg_statuses') }}
+),
 final as (
 
     select 
         *
     from orders 
     left join customers using (customer_id)
-
+    inner join statuses using (status)
 )
 
 select * from final

--- a/models/staging/stg_statuses.sql
+++ b/models/staging/stg_statuses.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('raw_statuses') }}

--- a/seeds/raw_statuses.csv
+++ b/seeds/raw_statuses.csv
@@ -1,0 +1,5 @@
+status,status_str
+returned,Order returned
+completed,Order completed
+shipped,Order shipped
+placed,Order placed


### PR DESCRIPTION
- Add the `statuses` seed.
- In the `orders` model, add the `status_str` to show the order status in a human-readable format.

![image](https://github.com/InfuseAI/jaffle_shop/assets/860633/bf517b1e-0f45-4dd4-971e-af9970619acf)

We found the unexpected metric change. 
![image](https://github.com/InfuseAI/jaffle_shop/assets/860633/18f3be14-2058-4edc-9423-ea3975682249)

It's due to wrong join. It should be left join rather than inner join.
https://github.com/InfuseAI/jaffle_shop/pull/19/files#diff-b19a7fe874c022775e17dd755f65e1fe34da1317c8ac7a1a49c3286f0f4b3f21L19
